### PR TITLE
Fixed typo of JaCoCo test reports dependsOn task

### DIFF
--- a/Example-AllLibraries/build.gradle
+++ b/Example-AllLibraries/build.gradle
@@ -114,7 +114,7 @@ dependencies {
 }
 
 // JaCoCo Test Reports, thanks to Nenick
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUniTest']) {
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
     group = 'Reporting'
     description = 'Generate Jacoco coverage reports after running tests.'
 

--- a/Example-Mockito/build.gradle
+++ b/Example-Mockito/build.gradle
@@ -114,7 +114,7 @@ dependencies {
 }
 
 // JaCoCo Test Reports, thanks to Nenick
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUniTest']) {
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
     group = 'Reporting'
     description = 'Generate Jacoco coverage reports after running tests.'
 

--- a/Example-Robolectric/build.gradle
+++ b/Example-Robolectric/build.gradle
@@ -114,7 +114,7 @@ dependencies {
 }
 
 // JaCoCo Test Reports, thanks to Nenick
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUniTest']) {
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
     group = 'Reporting'
     description = 'Generate Jacoco coverage reports after running tests.'
 

--- a/Example-RobolectricEasyMockPowerMock/build.gradle
+++ b/Example-RobolectricEasyMockPowerMock/build.gradle
@@ -114,7 +114,7 @@ dependencies {
 }
 
 // JaCoCo Test Reports, thanks to Nenick
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUniTest']) {
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
     group = 'Reporting'
     description = 'Generate Jacoco coverage reports after running tests.'
 

--- a/Example-RobolectricFlavors/build.gradle
+++ b/Example-RobolectricFlavors/build.gradle
@@ -114,7 +114,7 @@ dependencies {
 }
 
 // JaCoCo Test Reports, thanks to Nenick
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUniTest']) {
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
     group = 'Reporting'
     description = 'Generate Jacoco coverage reports after running tests.'
 


### PR DESCRIPTION
I think there is no "testDebugUniTest" tasks in this project.

the result of ./gradlew tasks is following

```
% ./gradlew tasks | grep test
build - Assembles and tests this project.
buildDependents - Assembles and tests this project and all projects that depend on it.
buildNeeded - Assembles and tests this project and all projects it depends on.
mockableAndroidJar - Creates a version of android.jar that's suitable for unit tests.
installDebugAndroidTest - Installs the android (on device) tests for the Debug build.
uninstallDebugAndroidTest - Uninstalls the android (on device) tests for the Debug build.
jacocoTestReport - Generate Jacoco coverage reports after running tests.
connectedAndroidTest - Installs and runs instrumentation tests for all flavors on connected devices.
connectedDebugAndroidTest - Installs and runs the tests for debug on connected devices.
deviceAndroidTest - Installs and runs instrumentation tests using all Device Providers.
test - Run unit tests for all variants.
testDebugUnitTest - Run unit tests for the debug build.
testReleaseUnitTest - Run unit tests for the release build.
```

I believe "testDebugUnitTest" is the task JaCoCo should depends on.